### PR TITLE
(wip) add CORS support, loaded from CORS_ORIGINS in env

### DIFF
--- a/faster_whisper_server/main.py
+++ b/faster_whisper_server/main.py
@@ -77,6 +77,17 @@ def load_model(model_name: str) -> WhisperModel:
 
 app = FastAPI()
 
+cors_origins = os.environ.get("CORS_ORIGINS", "").split(",")
+if cors_origins:
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=cors_origins,
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
+
 
 @app.get("/health")
 def health() -> Response:


### PR DESCRIPTION
This loads a list of origins from CORS_ORIGINS in env (comma separated) to allow.

This is useful for enabling browsers to directly request to the local faster-whisper-server, as currently they are blocked unless they use an intermediate server endpoint (see #48).

This is a work in progress and any help with updating the docker files to pass env files is appreciated!