### PR TITLE
feat: add api key

### DIFF
--- a/src/faster_whisper_server/config.py
+++ b/src/faster_whisper_server/config.py
@@ -176,6 +176,7 @@ class Config(BaseSettings):
     model_config = SettingsConfigDict(env_nested_delimiter="__")
 
     log_level: str = "debug"
+    api_key: str | None = None
     host: str = Field(alias="UVICORN_HOST", default="0.0.0.0")
     port: int = Field(alias="UVICORN_PORT", default=8000)
     allow_origins: list[str] | None = None

--- a/src/faster_whisper_server/security.py
+++ b/src/faster_whisper_server/security.py
@@ -1,0 +1,25 @@
+from typing import Annotated
+
+from fastapi import Depends, HTTPException
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+from faster_whisper_server.config import config
+
+auth_scheme = HTTPBearer(scheme_name="API key")
+API_KEY = config.api_key
+
+if not API_KEY:
+
+    def check_api_key():
+        # if No API key is set, so we don't check for it.
+        pass
+
+else:
+
+    def check_api_key(api_key: Annotated[HTTPAuthorizationCredentials, Depends(auth_scheme)]):
+        if api_key.scheme != "Bearer":
+            raise HTTPException(status_code=403, detail="Invalid authentication scheme")
+        if api_key.credentials != API_KEY:
+            raise HTTPException(status_code=403, detail="Unauthorized")
+
+        return api_key.credentials


### PR DESCRIPTION
# Why ?
In production, if you want to publish API on internet, you needs to protect the API by a key.

# What ? 
Add the possibility to set up an API key in the config file, using the API_KEY environment variable (optional).
The API_KEY scheme is a classic bearer token. This authentication appears on the Swagger interface if an API_KEY is set:
 
The API_KEY scheme is a classic bearer.  This authentication appears on the swagger here if a API_KEY is set : 
<img width="1437" alt="image" src="https://github.com/user-attachments/assets/84dfecc7-576c-4f99-985e-e341cd4c5718">

<img width="1439" alt="image" src="https://github.com/user-attachments/assets/2c2a0719-621b-42fc-9766-36e14ca3f2e4">

If the API_KEY is not set up, the authentication is not displayed.
