### PR TITLE
alias `timestamp_granularities[]` does not actually work

### DIFF
--- a/src/faster_whisper_server/main.py
+++ b/src/faster_whisper_server/main.py
@@ -321,8 +321,8 @@ def transcribe_file(
     response_format: Annotated[ResponseFormat, Form()] = config.default_response_format,
     temperature: Annotated[float, Form()] = 0.0,
     timestamp_granularities: Annotated[
-        list[Literal["segment", "word"]],
-        Form(alias="timestamp_granularities[]"),
+        list[str],
+        Form(),
     ] = ["segment"],
     stream: Annotated[bool, Form()] = False,
     hotwords: Annotated[str | None, Form()] = None,

--- a/tests/sse_test.py
+++ b/tests/sse_test.py
@@ -98,3 +98,31 @@ def test_transcription_srt(client: TestClient) -> None:
     text = text.replace("1", "YO")
     with pytest.raises(srt.SRTParseError):
         list(srt.parse(text))
+
+@pytest.mark.parametrize("timestamp_granularities", [["word"], ["word", "segment"]])
+def test_transcription_verbose_json(client: TestClient, timestamp_granularities) -> None:
+    with open("audio.wav", "rb") as f:
+        data = f.read()
+    kwargs = {
+        "files": {"file": ("audio.wav", data, "audio/wav")},
+        "data": {"response_format": "verbose_json", "stream": False, "timestamp_granularities": timestamp_granularities},
+    }
+    response = client.post("/v1/audio/transcriptions", **kwargs)
+    assert response.status_code == 200
+    assert "application/json" in response.headers["content-type"]
+    output = response.json()
+    assert output is not None
+
+@pytest.mark.parametrize("timestamp_granularities", [["word"], ["word", "segment"]])
+def test_transcription_verbose_json_with_alias_timestamp_granularities(client: TestClient, timestamp_granularities) -> None:
+    with open("audio.wav", "rb") as f:
+        data = f.read()
+    kwargs = {
+        "files": {"file": ("audio.wav", data, "audio/wav")},
+        "data": {"response_format": "verbose_json", "stream": False, "timestamp_granularities[]": timestamp_granularities},
+    }
+    response = client.post("/v1/audio/transcriptions", **kwargs)
+    assert response.status_code == 200
+    assert "application/json" in response.headers["content-type"]
+    output = response.json()
+    assert output is not None


### PR DESCRIPTION
This ends up breaking the non-aliased version as well - this means regardless of what you set in `timestamp_granularities` you'll always have the default value of `[segment]`

This leads to the issues we see in #29, #58

The core issue could be the special characters in `Form(alias=)` - but I can find several sources that claim that this should work - https://github.com/fastapi/fastapi/issues/5765

This warrants more exploration so I added two tests. To demonstrate the problem with the alias, I removed it in this PR and one of the tests pass.