### PR TITLE
Add image source label to dockerfiles

### DIFF
--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -1,4 +1,5 @@
 FROM ubuntu:22.04
+LABEL org.opencontainers.image.source="https://github.com/fedirz/faster-whisper-server"
 # `ffmpeg` is installed because without it `gradio` won't work with mp3(possible others as well) files
 # hadolint ignore=DL3008,DL3015,DL4006
 RUN apt-get update && \

--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -1,4 +1,5 @@
 FROM nvidia/cuda:12.2.2-cudnn8-runtime-ubuntu22.04
+LABEL org.opencontainers.image.source="https://github.com/fedirz/faster-whisper-server"
 # `ffmpeg` is installed because without it `gradio` won't work with mp3(possible others as well) files
 # hadolint ignore=DL3008,DL3015,DL4006
 RUN apt-get update && \


### PR DESCRIPTION
To get changelogs shown with Renovate a docker container has to add the source label described in the OCI Image Format Specification.

For reference: https://github.com/renovatebot/renovate/blob/main/lib/modules/datasource/docker/readme.md