### PR TITLE
docker volume permission fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,10 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 COPY --chown=ubuntu ./src ./pyproject.toml ./uv.lock ./
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --compile-bytecode --extra ui
+# Creating a directory for the cache to avoid the following error:
+# PermissionError: [Errno 13] Permission denied: '/home/ubuntu/.cache/huggingface/hub'
+# This error occurs because the volume is mounted as root and the `ubuntu` user doesn't have permission to write to it. Pre-creating the directory solves this issue.
+RUN mkdir -p $HOME/.cache/huggingface
 ENV WHISPER__MODEL=Systran/faster-whisper-large-v3
 ENV UVICORN_HOST=0.0.0.0
 ENV UVICORN_PORT=8000

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,9 @@ ENV UVICORN_HOST=0.0.0.0
 ENV UVICORN_PORT=8000
 ENV PATH="$HOME/faster-whisper-server/.venv/bin:$PATH"
 # https://huggingface.co/docs/huggingface_hub/en/package_reference/environment_variables#hfhubenablehftransfer
-ENV HF_HUB_ENABLE_HF_TRANSFER=1
+# NOTE: I've disabled this because it doesn't inside of Docker container. I couldn't pinpoint the exact reason. This doesn't happen when running the server locally.
+# RuntimeError: An error occurred while downloading using `hf_transfer`. Consider disabling HF_HUB_ENABLE_HF_TRANSFER for better error handling.
+ENV HF_HUB_ENABLE_HF_TRANSFER=0
 # https://huggingface.co/docs/huggingface_hub/en/package_reference/environment_variables#donottrack
 # https://www.reddit.com/r/StableDiffusion/comments/1f6asvd/gradio_sends_ip_address_telemetry_by_default/
 ENV DO_NOT_TRACK=1


### PR DESCRIPTION
- **fix: permission error due to volume being mounted as root**
  

- **fix: enabling `hf_transfer` breaks downloads when running as docker container**
  